### PR TITLE
docs: correct outdated property name 

### DIFF
--- a/docs/configuration/snippets/_configuration_properties.properties
+++ b/docs/configuration/snippets/_configuration_properties.properties
@@ -4,7 +4,7 @@ springwolf.docket.info.title=${spring.application.name}
 springwolf.docket.info.version=1.0.0
 
 springwolf.docket.servers.kafka.protocol=kafka
-springwolf.docket.servers.kafka.url=${spring.kafka.bootstrap-servers}
+springwolf.docket.servers.kafka.host=${spring.kafka.bootstrap-servers}
 
 # Springwolf - optional fields
 springwolf.enabled=true

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -37,7 +37,7 @@ springwolf.docket.info.title=${spring.application.name}
 springwolf.docket.info.version=1.0.0
 
 springwolf.docket.servers.kafka.protocol=kafka
-springwolf.docket.servers.kafka.url=${kafka.bootstrap.servers:localhost:29092}
+springwolf.docket.servers.kafka.host=${kafka.bootstrap.servers:localhost:29092}
 ```
 
 *Make sure to change the value of `springwolf.docket.base-package` to the package containing your listeners, so that Springwolf will automatically pick them up.*


### PR DESCRIPTION
correct outdated property name `springwolf.docket.servers.kafka.url` to `springwolf.docket.servers.kafka.host`

(This should be docs only, therefore no issue opened beforehand)