### PR TITLE
docs: Corrected the artifactId in Maven and Gradle dependency for swagger-core to 'swagger-core-jakarta'

### DIFF
--- a/docs/configuration/snippets/_schema_groovy.gradle
+++ b/docs/configuration/snippets/_schema_groovy.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    implementation 'io.swagger.core.v3:swagger-core:2.2.22'
+    implementation 'io.swagger.core.v3:swagger-core-jakarta:2.2.22'
 }

--- a/docs/configuration/snippets/_schema_maven.xml
+++ b/docs/configuration/snippets/_schema_maven.xml
@@ -1,7 +1,7 @@
 <dependencies>
     <dependency>
         <groupId>io.swagger.core.v3</groupId>
-        <artifactId>swagger-core</artifactId>
+        <artifactId>swagger-core-jakarta</artifactId>
         <version>2.2.22</version>
     </dependency>
 </dependencies>


### PR DESCRIPTION
This commit updates the Maven and Gradle dependencies for the swagger-core library to use the correct artifactId. The `swagger-core-jakarta` artifact is the same one being used as a transitive dependency in `springwolf-core`.